### PR TITLE
Match on pathname instead of filename.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,3 +6,5 @@ Changelog of watchman
 ----------------
 
 - Initial project structure created with nensskel 1.35.
+
+- Match on pathname instead of filename.

--- a/CREDITS.rst
+++ b/CREDITS.rst
@@ -1,4 +1,4 @@
 Credits
 =======
 
-- TODO started this library
+- Nelen & Schuurmans

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,9 @@ tests_require = [
 
 setup(name='watchman',
       version=version,
-      description="TODO",
+      description=(
+          "Watch directories for new files and send tasks to a queue "
+          "for futher asynchronous processing."),
       long_description=long_description,
       # Get strings from http://www.python.org/pypi?%3Aaction=list_classifiers
       classifiers=['Programming Language :: Python'],

--- a/watchman/config-example.py
+++ b/watchman/config-example.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from collections import OrderedDict
 import os
 
 SETTINGS_DIR = os.path.dirname(os.path.realpath(__file__))
@@ -38,14 +39,17 @@ LOGGING = {
 }
 
 # https://docs.python.org/2/library/fnmatch.html
-PATTERNS = {
-    '*': 'proj.tasks.echo',
-}
+# Order does matter: most specific first.
+PATTERNS = OrderedDict(
+    ('*/events/*.csv', 'proj.tasks.import_events'),
+    ('*.csv', 'proj.tasks.import_timeseries'),
+    ('*', 'proj.tasks.echo'),
+)
 
 # http://seb-m.github.io/pyinotify/
 WATCHES = [
     {'path': '/foo'},
-    {'path': '/bar'},
+    {'path': '/bar', 'rec': True},
 ]
 
 # Files may be moved beforehand.

--- a/watchman/config-example.py
+++ b/watchman/config-example.py
@@ -40,11 +40,11 @@ LOGGING = {
 
 # https://docs.python.org/2/library/fnmatch.html
 # Order does matter: most specific first.
-PATTERNS = OrderedDict(
+PATTERNS = OrderedDict([
     ('*/events/*.csv', 'proj.tasks.import_events'),
     ('*.csv', 'proj.tasks.import_timeseries'),
     ('*', 'proj.tasks.echo'),
-)
+])
 
 # http://seb-m.github.io/pyinotify/
 WATCHES = [

--- a/watchman/config-example.py
+++ b/watchman/config-example.py
@@ -49,7 +49,7 @@ PATTERNS = OrderedDict([
 # http://seb-m.github.io/pyinotify/
 WATCHES = [
     {'path': '/foo'},
-    {'path': '/bar', 'rec': True},
+    {'path': '/bar', 'rec': True},  # watch subdirectories too
 ]
 
 # Files may be moved beforehand.

--- a/watchman/notify.py
+++ b/watchman/notify.py
@@ -61,10 +61,10 @@ class FileHandler(pyinotify.ProcessEvent):
 
         # Now that the file has been moved, notify the task server.
 
-        filename = event.name.lower()
+        pathname = event.pathname.lower()
 
-        for pattern in cfg.PATTERNS.viewkeys():
-            if fnmatch.fnmatch(filename, pattern):
+        for pattern in cfg.PATTERNS:
+            if fnmatch.fnmatch(pathname, pattern):
                 try:
                     taskname = cfg.PATTERNS[pattern]
                     logger.info('Sending task %s', taskname)


### PR DESCRIPTION
At the moment, there is a one-to-one relationship between file extension and task to be executed. This PR allows for more flexibility, for example:

```
PATTERNS = OrderedDict(
    ('*/events/*.csv', 'proj.tasks.import_events'),
    ('*.csv', 'proj.tasks.import_timeseries'),
)


```